### PR TITLE
fix: allow $schema property as string [no issue]

### DIFF
--- a/anonymization-file-schema.json
+++ b/anonymization-file-schema.json
@@ -5,7 +5,9 @@
   "version": "1.0.0",
   "type": "object",
   "patternProperties": {
-    "schema": {"type": "string"}
+    "schema": {
+      "type": "string"
+    }
   },
   "additionalProperties": {
     "type": "object",

--- a/anonymization-file-schema.json
+++ b/anonymization-file-schema.json
@@ -5,7 +5,7 @@
   "version": "1.0.0",
   "type": "object",
   "patternProperties": {
-  	"schema": {"type": "string"}
+    "schema": {"type": "string"}
   },
   "additionalProperties": {
     "type": "object",

--- a/anonymization-file-schema.json
+++ b/anonymization-file-schema.json
@@ -4,6 +4,9 @@
   "description": "Schema for defining anonymization rules for database fields",
   "version": "1.0.0",
   "type": "object",
+  "patternProperties": {
+  	"schema": {"type": "string"}
+  },
   "additionalProperties": {
     "type": "object",
     "description": "Table name",


### PR DESCRIPTION
### Context

We were getting this warning
<img width="1086" height="219" alt="image" src="https://github.com/user-attachments/assets/01b65c87-2114-4f2b-851d-6b0b69ee054f" />

### Solution

Allow `$schema` property to contain a string instead of an object
